### PR TITLE
configure GOROOT with go env command

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -100,6 +100,12 @@ async function finish(options: Options) {
     }
   }
   const args = ["-parallel-finish", "-service=github"];
+  if (options.ignore) {
+    args.push(`-ignore=${options.ignore}`);
+  }
+  if (core.isDebug()) {
+    args.push("-debug");
+  }
   await exec.exec(get_goveralls_path(), args, {
     env: env,
     cwd: options.working_directory,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -106,6 +106,14 @@ async function finish(options: Options) {
 }
 
 // run `go env` and return its value.
+//
+// goveralls doesn't use the `go list` command but uses the `go/build` package.
+// `go list` sees the `GOROOT` environment value, and its default value is typically `/usr/local/go`.
+// But sometimes it isn't, e.g. the `go` command is built from the source and customized.
+//
+// So if `GOROOT` is not configured, get its value by running `go env GOROOT`.
+//
+// see https://github.com/shogo82148/actions-goveralls/pull/216 and https://github.com/shogo82148/actions-goveralls/issues/214
 async function go_env(name: string): Promise<string> {
   let out = "";
   await exec.exec("go", ["env", name], {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -96,6 +96,7 @@ async function finish(options: Options) {
     const value =
       process.env[name] || (name.match(/^GO/) && (await go_env(name)));
     if (value) {
+      env[name] = value;
     }
   }
   const args = ["-parallel-finish", "-service=github"];

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -60,11 +60,10 @@ async function run(options: Options) {
   };
 
   for (const name of go_environment_values) {
-    const value = process.env[name];
+    const value =
+      process.env[name] || (name.match(/^GO/) && (await go_env(name)));
     if (value) {
       env[name] = value;
-    } else if (name.match(/^GO/)) {
-      env[name] = await go_env(name);
     }
   }
   const args = ["-service=github"];
@@ -94,11 +93,9 @@ async function finish(options: Options) {
     COVERALLS_TOKEN: options.token,
   };
   for (const name of go_environment_values) {
-    const value = process.env[name];
+    const value =
+      process.env[name] || (name.match(/^GO/) && (await go_env(name)));
     if (value) {
-      env[name] = value;
-    } else if (name.match(/^GO/)) {
-      env[name] = await go_env(name);
     }
   }
   const args = ["-parallel-finish", "-service=github"];

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -63,6 +63,8 @@ async function run(options: Options) {
     const value = process.env[name];
     if (value) {
       env[name] = value;
+    } else if (name.match(/^GO/)) {
+      env[name] = await go_env(name);
     }
   }
   const args = ["-service=github"];
@@ -95,6 +97,8 @@ async function finish(options: Options) {
     const value = process.env[name];
     if (value) {
       env[name] = value;
+    } else if (name.match(/^GO/)) {
+      env[name] = await go_env(name);
     }
   }
   const args = ["-parallel-finish", "-service=github"];
@@ -102,6 +106,19 @@ async function finish(options: Options) {
     env: env,
     cwd: options.working_directory,
   });
+}
+
+// run `go env` and return its value.
+async function go_env(name: string): Promise<string> {
+  let out = "";
+  await exec.exec("go", ["env", name], {
+    listeners: {
+      stdout: (data: Buffer) => {
+        out += data.toString();
+      },
+    },
+  });
+  return out;
 }
 
 function get_goveralls_path(): string {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -118,7 +118,7 @@ async function go_env(name: string): Promise<string> {
       },
     },
   });
-  return out;
+  return out.trim();
 }
 
 function get_goveralls_path(): string {


### PR DESCRIPTION
goveralls doesn't use the `go list` command but uses the `go/build` package.
`go list` sees the `GOROOT` environment value, and its default value is typically `/usr/local/go`.
But sometimes it isn't, e.g. the `go` command is built from the source and customized.

So if `GOROOT` is not configured, get its value by running `go env GOROOT`.

fixes https://github.com/shogo82148/actions-goveralls/issues/214