### PR TITLE
drop support of macos-12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,10 @@ jobs:
           - ubuntu-20.04
           - macos-14 # for arm64
           - macos-13 # for x64
-          - macos-12
           - windows-2022
           - windows-2019
         go:
-          - "1.11" # minumum version goveralls supports
+          - "1.11" # minimum version goveralls supports
           - "oldstable"
           - "stable"
         exclude:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typo in the GitHub Actions workflow comment, correcting "minumum" to "minimum"

- **Chores**
	- Updated the matrix of operating systems for testing by removing "macos-12"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->