### PR TITLE
drop support for windows-2019

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
           - macos-14 # for arm64
           - macos-13 # for x64
           - windows-2022
-          - windows-2019
         go:
           - "1.11" # minimum version goveralls supports
           - "oldstable"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * CI test matrix updated to exclude Windows 2019.
* **Chores**
  * Streamlined continuous integration by removing Windows 2019 from test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->