### PR TITLE
add windows-2025 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
           - ubuntu-22.04-arm
           - macos-14 # for arm64
           - macos-13 # for x64
+          - windows-2025
           - windows-2022
           - windows-2019
         go:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded CI test matrix to include a Windows 2025 environment, increasing platform coverage and confidence in cross-platform behavior.
  * Helps catch Windows-specific regressions earlier and improves reliability across supported operating systems.
  * No changes to test logic or steps; existing tests now run on the additional environment without impacting application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->