### PR TITLE
add windows-11-arm to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
           - ubuntu-22.04-arm
           - macos-14 # for arm64
           - macos-13 # for x64
+          - windows-11-arm # for arm64
           - windows-2025
           - windows-2022
         go:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,9 @@ jobs:
           # Go 1.11 is not supported on Apple Silicon
           - os: macos-14
             go: "1.11"
+          # Go 1.11 is not supported on Windows 11 ARM
+          - os: windows-11-arm
+            go: "1.11"
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded the automated test matrix to include Windows 11 on ARM64, increasing OS/architecture coverage.
  * Updated CI exclusions to avoid incompatible combinations, improving test reliability and reducing false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->