### PR TITLE
bump Go 1.25.0

### DIFF
--- a/dummy.go
+++ b/dummy.go
@@ -1,6 +1,0 @@
-//+build tools
-
-package actions
-
-// dummy import for managing the version of goveralls with go.mod.
-import . "github.com/mattn/goveralls"

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/shogo82148/actions-goveralls
 
-go 1.23.5
-
-require github.com/mattn/goveralls v0.0.12
+go 1.25.0
 
 require (
+	github.com/mattn/goveralls v0.0.12 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/tools v0.8.0 // indirect
 )
+
+tool github.com/mattn/goveralls

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -8,4 +8,4 @@ docker run --rm \
     -v actions-goveralls-cache:/go/pkg/mod \
     -v actions-goveralls-cache:/root/.cache \
     -v "$CURRENT":/go/src/github.com/shogo82148/actions-goveralls \
-    -w /go/src/github.com/shogo82148/actions-goveralls golang:1.23.5 "$@"
+    -w /go/src/github.com/shogo82148/actions-goveralls golang:1.25.0 "$@"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded Go toolchain to version 1.25.0 for builds and development.
  - Updated Docker-based run script to use the Go 1.25.0 image for consistency.
  - Streamlined tooling management by removing an obsolete placeholder; no impact on runtime behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->